### PR TITLE
Update Deployment to use separate branch

### DIFF
--- a/.github/workflows/build-deploy docker.yml
+++ b/.github/workflows/build-deploy docker.yml
@@ -69,8 +69,7 @@ jobs:
         shell: bash
 
       - name: Trigger a deployment
-        uses: darnfish/watchtower-update@v3.2
+        uses: darnfish/watchtower-update@v3.3
         with:
           url: "${{ secrets.WATCHTOWER_URL }}"
           api_token: "${{ secrets.WATCHTOWER_API_TOKEN }}"
-          images: "ghcr.io/${{ env.REPO }}:latest"

--- a/.github/workflows/build-deploy docker.yml
+++ b/.github/workflows/build-deploy docker.yml
@@ -64,10 +64,6 @@ jobs:
       - name: Lowercase the repo name and username
         run: echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
 
-      - name: Sleep
-        run: sleep 200
-        shell: bash
-
       - name: Trigger a deployment
         uses: darnfish/watchtower-update@v3.3
         with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Simple Meal
+
+## Deploying to Production
+
+Create a Pull Request from main branch to deploy branch, and merge it. Once you merge it, the GitHub Action will run to build and deploy the new version at [simplemeal.live](https://simplemeal.live/).
+
 ## Development workflow for developers
 
 Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)


### PR DESCRIPTION
- Use the `deploy` branch to build and deploy a new version onto the production website.
- Achieve this by following the instructions [here](https://github.com/FYDP-Team1/Simple-Meal?tab=readme-ov-file#deploying-to-production).